### PR TITLE
Permit x and y reuse

### DIFF
--- a/draft-mccallum-kitten-krb-spake-preauth-00.xml
+++ b/draft-mccallum-kitten-krb-spake-preauth-00.xml
@@ -433,6 +433,11 @@ KEY_USAGE_SPAKE_FACTOR                  TBD
         specified in <xref target="SEC1"/> section 2.3.8.  For other groups,
         decode the octet string as specified by the group.</t>
       </list></t>
+      <t>The KDC chooses a secret scalar value x and the client chooses a
+      secret scalar value y. As required by the SPAKE algorithm, these values
+      are chosen randomly and uniformly. The KDC and client MAY reuse x or y
+      values across multiple pre-authentication operations using the same
+      group.</t>
       <t>The SPAKE algorithm requires constants M and N for each
       group.  These constants MUST be taken from <xref
       target="I-D.irtf-cfrg-spake2"/> section 3 or computed using the


### PR DESCRIPTION
The SPAKE2 draft doesn't say anything about reusing x and y. We
believe there is no problem with reuse except for the impact on
forward secrecy (which we should discuss in security considerations;
that will come in a later commit). Add a note about the selection of x
and y values to the SPAKE parameters section, and permit them to be
reused.