### PR TITLE
spake: remove confusing security considerations paragraph

### DIFF
--- a/draft-ietf-kitten-krb-spake-preauth-00.xml
+++ b/draft-ietf-kitten-krb-spake-preauth-00.xml
@@ -618,10 +618,6 @@ KEY_USAGE_SPAKE_TRANSCRIPT              TBD
       the same amount of time, and make the same observable communications to
       other servers.</t>
 
-      <t>Given that each EncryptedData will begin a new encryption context,
-      a failure to properly derive the encryption keys will result in a
-      situation where the risk of compromise is non-negligible.</t>
-
       <t>Weak checksums present a risk to the transcript checksum. Any etype
       with a checksum based on one of the following algorithms MUST NOT be
       used:


### PR DESCRIPTION
Ben and I thought this paragraph was confusing and not of much value.

RFC 3961 is designed to allow multiple independent encryptions using the same key and key usage without compromising the key or either plaintext.  Substitution attacks become a possibility, but it doesn't seem worth discussing attacks at that level against a broken variant of the protocol.
